### PR TITLE
do not check Advanced options by default in sinkwidget

### DIFF
--- a/src/sinkwidget.cc
+++ b/src/sinkwidget.cc
@@ -156,7 +156,6 @@ void SinkWidget::setDigital(bool digital) {
 #if HAVE_EXT_DEVICE_RESTORE_API
     if (digital) {
         encodingSelect->show();
-        advancedOptions->setChecked(true);
     } else {
         /* advancedOptions has sensitive=false by default */
         encodingSelect->hide();


### PR DESCRIPTION
pavucontrol-gtk doesn't do it and I see no reason why this port should do