### PR TITLE
Make the 'Show:' text look like Pavucontrol GTK

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -38,8 +38,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>730</width>
-            <height>423</height>
+            <width>724</width>
+            <height>35</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -63,7 +63,7 @@
        <item row="1" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
-          <string>Show:</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;right&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Show:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -103,8 +103,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>730</width>
-            <height>423</height>
+            <width>724</width>
+            <height>35</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -128,7 +128,7 @@
        <item row="1" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Show:</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;right&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Show:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -168,8 +168,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>730</width>
-            <height>423</height>
+            <width>724</width>
+            <height>35</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -193,7 +193,7 @@
        <item row="1" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Show:</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;right&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Show:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -233,8 +233,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>730</width>
-            <height>423</height>
+            <width>724</width>
+            <height>35</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -258,7 +258,7 @@
        <item row="1" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
-          <string>Show:</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;right&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Show:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>
@@ -308,8 +308,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>730</width>
-            <height>433</height>
+            <width>724</width>
+            <height>35</height>
            </rect>
           </property>
           <property name="sizePolicy">


### PR DESCRIPTION
At the moment, on the bottom of Pavucontrol GTK, the `Show:` text looks like this:

![Show is bold and aligned to the right](http://storage3.static.itmages.com/i/16/0925/h_1474779674_7507166_ee17c5f375.png)

Pavucontrol Qt looks like this:
![Show is not bold and aligned to the left](http://storage6.static.itmages.com/i/16/0925/h_1474779772_1478975_04ab528b17.png)

This fixes Pavucontrol Qt so it looks like this:
![Show is bold and aligned to the right, just like Pavucontrol GTK](http://storage1.static.itmages.com/i/16/0925/h_1474780199_7590715_d3f15d7451.png)

Since this is a Qt port of Pavucontrol, it's probably a good idea to keep the same general style.
