### PR TITLE
Simply differentiate the naming to avoid menu duplication

### DIFF
--- a/src/pavucontrol-qt.desktop.in
+++ b/src/pavucontrol-qt.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.0
-Name=Qt PulseAudio Volume Control
+Name=PulseAudio Volume Control (Qt)
 GenericName=Volume Control
 Comment=Adjust the volume level
 Exec=pavucontrol-qt

--- a/src/pavucontrol-qt.desktop.in
+++ b/src/pavucontrol-qt.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.0
-Name=PulseAudio Volume Control
+Name=Qt PulseAudio Volume Control
 GenericName=Volume Control
 Comment=Adjust the volume level
 Exec=pavucontrol-qt


### PR DESCRIPTION
This is not the best solution, but is solve in a temporary base if some
improved action is find.
Use an alternative icon could be a possibility to, but then the current
approach follows the icons naming standard pattern and this would
unlikely break the theme standards